### PR TITLE
Add file version detection and improve version matching.

### DIFF
--- a/qsys-launcher/package-lock.json
+++ b/qsys-launcher/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qsys-launcher",
-  "version": "0.1.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qsys-launcher",
-      "version": "0.1.0",
+      "version": "1.1.0",
       "dependencies": {
         "@fluentui/react-components": "^9.63.0",
         "@tauri-apps/api": "^2",
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2",
+        "@types/node": "^25.0.3",
         "@types/react": "^18.3.1",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.4",
@@ -68,6 +69,7 @@
       "integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -780,6 +782,7 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.0.tgz",
       "integrity": "sha512-lGTor4VlXcesUMh1cupTUTDoCxMb0V6bm3CnxHzQcw8Eaf1jQbgQX4i02fYgT0vJ82tb5MZ4CZk1LRGkktJCzg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.0",
         "@floating-ui/utils": "^0.2.9"
@@ -3434,6 +3437,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
+      "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
@@ -3445,6 +3459,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.20.tgz",
       "integrity": "sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -3455,6 +3470,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -3499,6 +3515,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -3585,7 +3602,8 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-autoplay": {
       "version": "8.6.0",
@@ -3821,6 +3839,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3879,6 +3898,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3891,6 +3911,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4062,6 +4083,13 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -4120,6 +4148,7 @@
       "integrity": "sha512-BiReIiMS2fyFqbqNT/Qqt4CVITDU9M9vE+DKcVAsB+ZV0wvTKd+3hMbkpxz1b+NmEDMegpVbisKiAZOnvO92Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/qsys-launcher/package.json
+++ b/qsys-launcher/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qsys-launcher",
   "private": true,
-  "version": "0.1.0",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2",
+    "@types/node": "^25.0.3",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",

--- a/qsys-launcher/src-tauri/Cargo.lock
+++ b/qsys-launcher/src-tauri/Cargo.lock
@@ -2765,8 +2765,9 @@ dependencies = [
 
 [[package]]
 name = "qsys-launcher"
-version = "0.1.0"
+version = "1.1.0"
 dependencies = [
+ "regex",
  "serde",
  "serde_json",
  "tauri",

--- a/qsys-launcher/src-tauri/Cargo.toml
+++ b/qsys-launcher/src-tauri/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "qsys-launcher"
-version = "0.1.0"
-description = "A Tauri App"
-authors = ["you"]
+version = "1.1.0"
+description = "QSC Q-Sys Designer Launcher"
+authors = ["Zach Lisko (mckay115)", "Riley Watson (randomrileywat)"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -22,4 +22,5 @@ tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+regex = "1"
 

--- a/qsys-launcher/src-tauri/src/lib.rs
+++ b/qsys-launcher/src-tauri/src/lib.rs
@@ -1,11 +1,10 @@
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::env;
 use std::fs;
 use std::path::Path;
 use std::process::Command;
-use std::sync::Arc;
-use tauri::Emitter;
 use tauri::Manager;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -51,10 +50,23 @@ fn get_installed_versions() -> Vec<QSysVersion> {
         }
     }
 
-    // Sort versions in descending order (highest/newest version at the top)
-    versions.sort_by(|a, b| b.name.to_lowercase().cmp(&a.name.to_lowercase()));
+    // Sort versions in ascending order using semantic versioning
+    versions.sort_by(|a, b| {
+        let a_nums = extract_version_numbers(&a.name);
+        let b_nums = extract_version_numbers(&b.name);
+        a_nums.cmp(&b_nums)
+    });
 
     versions
+}
+
+// Helper function to extract version numbers for proper sorting
+fn extract_version_numbers(name: &str) -> Vec<u32> {
+    // Find all numbers in the version string (e.g., "Q-SYS Designer 9.13" -> [9, 13])
+    let re = Regex::new(r"(\d+)").unwrap();
+    re.find_iter(name)
+        .filter_map(|m| m.as_str().parse::<u32>().ok())
+        .collect()
 }
 
 // Function to launch the selected version with an optional file
@@ -106,40 +118,79 @@ fn get_file_arg() -> Option<String> {
     None
 }
 
-// Simple struct to store file path in app state
-struct FilePath(String);
+// Extract version number from .qsys file content
+fn get_version_from_file(file_path: &str) -> Option<String> {
+    // Read file as binary
+    let content = match fs::read(file_path) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            println!("Error reading file: {}", e);
+            return None;
+        }
+    };
+
+    // Search for Version=X.X.X.X pattern in binary content
+    // Convert to string lossy to handle any encoding
+    let content_str = String::from_utf8_lossy(&content);
+    
+    // Use regex to find Version=X.X.X.X pattern (with or without quotes)
+    let re = Regex::new(r#"Version="?(\d+(\.\d+)*)"?"#).unwrap();
+    
+    if let Some(captures) = re.captures(&content_str) {
+        if let Some(version_match) = captures.get(1) {
+            return Some(version_match.as_str().to_string());
+        }
+    }
+    
+    None
+}
+
+// Struct to hold file info passed to frontend
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct FileInfo {
+    path: String,
+    version: Option<String>,
+}
+
+// Command to get file info from app state
+#[tauri::command]
+fn get_file_info(state: tauri::State<FileInfo>) -> FileInfo {
+    (*state).clone()
+}
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .setup(|app| {
-            // Get file arg if present
-            if let Some(file_path) = get_file_arg() {
-                // Store the file path in app state
+            // Get file arg if present and create FileInfo
+            let file_info = if let Some(file_path) = get_file_arg() {
                 println!("Passing file argument: {}", file_path);
 
-                // Create app state with file path
-                app.manage(FilePath(file_path.clone()));
+                // Extract version from the .qsys file
+                let file_version = get_version_from_file(&file_path);
+                if let Some(ref version) = file_version {
+                    println!("Detected file version: {}", version);
+                }
 
-                // Get a handle to the app to emit events
-                let app_handle = app.app_handle().clone();
-                let file_path_arc = Arc::new(file_path);
+                FileInfo {
+                    path: file_path,
+                    version: file_version,
+                }
+            } else {
+                FileInfo::default()
+            };
 
-                // Set a timeout to emit the file path to the frontend - reduced delay
-                let file_path_clone = Arc::clone(&file_path_arc);
-                std::thread::spawn(move || {
-                    std::thread::sleep(std::time::Duration::from_millis(500));
-                    let _ = app_handle.emit("file-requested", (*file_path_clone).clone());
-                });
-            }
+            // Always manage state (even if empty)
+            app.manage(file_info);
 
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
             get_installed_versions,
             launch_application,
-            close_application
+            close_application,
+            get_file_info
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/qsys-launcher/src-tauri/tauri.conf.json
+++ b/qsys-launcher/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "QSC Q-Sys Launcher",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "identifier": "com.qsc.qlauncher",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/qsys-launcher/src/App.tsx
+++ b/qsys-launcher/src/App.tsx
@@ -13,10 +13,10 @@ import {
   useId,
   mergeClasses,
 } from "@fluentui/react-components";
-import { listen } from "@tauri-apps/api/event";
-// Import images directly
-import iconSmall from "@assets/img/icon-small.png";
-import iconLarge from "@assets/img/icon.png";
+
+// Public folder assets (served at root path)
+const iconSmall = "/img/icon-small.png";
+const iconLarge = "/img/icon.png";
 
 // Type for QSys version
 interface QSysVersion {
@@ -25,12 +25,32 @@ interface QSysVersion {
   exe_type: string;
 }
 
+// Type for file info from backend
+interface FileInfo {
+  path: string;
+  version: string | null;
+}
+
 // Helper function to extract file name without extension
 const getFileNameWithoutExtension = (filePath: string): string => {
   // Extract just the file name without the directory path
   const fileName = filePath.split(/[\\/]/).pop() || "";
   // Remove the extension
   return fileName.replace(/\.[^/.]+$/, "");
+};
+
+// Helper function to check if file version matches installed version (first two numbers)
+const versionsMatch = (fileVersion: string | null, installedVersionName: string): boolean => {
+  if (!fileVersion) return false;
+  
+  // Extract first two numbers from file version (e.g., "9.13" from "9.13.1.0")
+  const fileMatch = fileVersion.match(/^(\d+\.\d+)/);
+  if (!fileMatch) return false;
+  const filePrefix = fileMatch[1];
+  
+  // Check if installed version name contains this prefix
+  // Installed versions are like "Q-SYS Designer 9.13" or just "9.13"
+  return installedVersionName.includes(filePrefix);
 };
 
 // Custom styles using Fluent UI - Windows native styling
@@ -76,12 +96,25 @@ const useStyles = makeStyles({
     backgroundColor: tokens.colorNeutralBackground2,
     ...shorthands.padding("8px", "12px"),
     ...shorthands.borderRadius(tokens.borderRadiusMedium),
-    fontSize: "14px",
-    fontWeight: tokens.fontWeightSemibold,
     marginBottom: "16px",
-    color: tokens.colorNeutralForeground1,
     border: `1px solid ${tokens.colorNeutralStroke2}`,
     display: "inline-block",
+  },
+  fileName: {
+    fontSize: "14px",
+    fontWeight: tokens.fontWeightSemibold,
+    color: tokens.colorNeutralForeground1,
+    display: "block",
+  },
+  fileVersion: {
+    fontSize: "12px",
+    color: tokens.colorNeutralForeground3,
+    marginTop: "2px",
+    display: "block",
+  },
+  versionButtonMatched: {
+    backgroundColor: tokens.colorBrandBackground2,
+    ...shorthands.borderColor(tokens.colorBrandStroke1),
   },
   content: {
     flex: "1 1 auto",
@@ -171,11 +204,13 @@ const VersionButton = memo(
   ({
     version,
     isSelected,
+    isMatched,
     onClick,
     onKeyDown,
   }: {
     version: QSysVersion;
     isSelected: boolean;
+    isMatched: boolean;
     onClick: () => void;
     onKeyDown: (e: React.KeyboardEvent) => void;
   }) => {
@@ -185,7 +220,8 @@ const VersionButton = memo(
       <div
         className={mergeClasses(
           styles.versionButton,
-          isSelected && styles.versionButtonSelected
+          isSelected && styles.versionButtonSelected,
+          isMatched && !isSelected && styles.versionButtonMatched
         )}
         onClick={onClick}
         onKeyDown={onKeyDown}
@@ -204,6 +240,7 @@ function App() {
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [filePath, setFilePath] = useState<string | null>(null);
+  const [fileVersion, setFileVersion] = useState<string | null>(null);
   const [selectedVersion, setSelectedVersion] = useState<string | null>(null);
   const styles = useStyles();
   const messageId = useId("message");
@@ -217,19 +254,28 @@ function App() {
     img2.src = iconLarge;
   }, []);
 
-  // Listen for file-requested event
+  // Get file info from backend on mount
   useEffect(() => {
     let mounted = true;
 
-    const unlisten = listen<string>("file-requested", (event) => {
-      if (event.payload && mounted) {
-        setFilePath(event.payload);
+    const getFileInfo = async () => {
+      try {
+        const fileInfo = await invoke<FileInfo>("get_file_info");
+        console.log("Received file info:", fileInfo);
+        if (mounted && fileInfo.path) {
+          setFilePath(fileInfo.path);
+          setFileVersion(fileInfo.version);
+          console.log("Set fileVersion to:", fileInfo.version);
+        }
+      } catch (err) {
+        console.error("Error getting file info:", err);
       }
-    });
+    };
+
+    getFileInfo();
 
     return () => {
       mounted = false;
-      unlisten.then((fn) => fn());
     };
   }, []);
 
@@ -249,9 +295,12 @@ function App() {
         if (!mounted) return;
         setVersions(installedVersions);
 
-        // Auto-select first version if available (which is now the newest one)
-        if (installedVersions.length > 0) {
-          setSelectedVersion(installedVersions[0].path);
+        // Auto-select matching version if there's a file version, otherwise no auto-selection
+        if (installedVersions.length > 0 && fileVersion) {
+          const matchingVersion = installedVersions.find(v => versionsMatch(fileVersion, v.name));
+          if (matchingVersion) {
+            setSelectedVersion(matchingVersion.path);
+          }
         }
       } catch (err) {
         if (!mounted) return;
@@ -343,7 +392,10 @@ function App() {
 
         {filePath && (
           <div className={styles.filePath}>
-            {getFileNameWithoutExtension(filePath)}
+            <span className={styles.fileName}>{getFileNameWithoutExtension(filePath)}</span>
+            {fileVersion && (
+              <span className={styles.fileVersion}>Version: {fileVersion}</span>
+            )}
           </div>
         )}
 
@@ -376,6 +428,7 @@ function App() {
                 key={version.path}
                 version={version}
                 isSelected={selectedVersion === version.path}
+                isMatched={versionsMatch(fileVersion, version.name)}
                 onClick={() => {
                   setSelectedVersion(version.path);
                   launchApplication(version.path);

--- a/qsys-launcher/vite.config.ts
+++ b/qsys-launcher/vite.config.ts
@@ -1,8 +1,11 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
-import { resolve } from "path";
+import path from "path";
+import { fileURLToPath } from "url";
 
-// @ts-expect-error process is a nodejs global
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 const host = process.env.TAURI_DEV_HOST;
 
 // https://vitejs.dev/config/
@@ -12,8 +15,7 @@ export default defineConfig(async () => ({
   // Add resolve for assets
   resolve: {
     alias: {
-      "@": resolve(__dirname, "src"),
-      "@assets": resolve(__dirname, "public"),
+      "@": path.resolve(__dirname, "src"),
     },
   },
 


### PR DESCRIPTION
Introduces backend logic to extract the Q-SYS Designer version from .qsys files and exposes this info to the frontend. The UI now displays the file version and highlights the matching installed version, improving user experience when opening files. Also updates project metadata, adds @types/node, and refines asset handling and version sorting. Fixed "This app can't run on your PC" issue with certain Windows 11 processors.